### PR TITLE
Set of modifications/fixes related to the Pie Charts Pop-ups and Legends

### DIFF
--- a/my_code_tests.py
+++ b/my_code_tests.py
@@ -1,36 +1,31 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-from dash.dependencies import Input, Output
+import plotly.express as px
 
 app = dash.Dash(__name__)
 
-app.layout = html.Div([
-    html.H3("Checklist with Text Visibility"),
-    dcc.Checklist(
-        id='text-checklist',
-        options=[
-            {'label': 'Text 1', 'value': 'text1'},
-            {'label': 'Text 2', 'value': 'text2'},
-            {'label': 'Text 3', 'value': 'text3'}
-        ],
-        value=[]  # Initial values (all unchecked)
-    ),
-    html.Div(id='text-container')
-])
+# Sample data for the pie chart
+data = {'labels': ['Category A', 'Category B', 'Category C'],
+        'values': [30, 45, 25]}
 
-@app.callback(
-    Output('text-container', 'children'),
-    [Input('text-checklist', 'value')]
+# Create the pie chart figure
+fig = px.pie(data, values='values', names='labels')
+
+# Update the hovertemplate for larger pop-ups
+fig.update_traces(hovertemplate='<b>%{label}</b> (%{percent}) <br> Dinero(EUR): %{value}')
+
+# Update the layout to position the legend and increase hoverinfo font size
+fig.update_layout(
+    legend=dict(x=1, y=0.5),  # Adjust x and y values as needed
+    hoverlabel=dict(font_size=16)  # Adjust font size as desired
 )
-def update_text(selected_values):
-    texts = {
-        'text1': html.P("This is Text 1."),
-        'text2': html.P("This is Text 2."),
-        'text3': html.P("This is Text 3.")
-    }
-    displayed_texts = [texts[value] for value in selected_values]
-    return displayed_texts
+
+app.layout = html.Div(children=[
+    html.H1(children="Pie Chart with Larger Hover Pop-ups"),
+    dcc.Graph(id='pie-chart', figure=fig)
+])
 
 if __name__ == '__main__':
     app.run_server(debug=True)
+

--- a/pages/risk_diversification/risk_diversification_body.py
+++ b/pages/risk_diversification/risk_diversification_body.py
@@ -1,6 +1,7 @@
 from dash import dcc
 from dash.dash_table import DataTable
 from dash.dash_table.Format import Format, Group
+import locale
 
 import pages.risk_diversification.risk_diversification_data as risk_diversification_data
 import pages.risk_diversification.risk_diversification_titles as risk_diversification_titles
@@ -78,7 +79,7 @@ def get_panel_body_row(pie_chart, table, pie_chart_id, table_id):
     return data_row
 
 
-## MUEVO ESTO A UN ARCHIVO DE PANEL COMPONENTS??????? y ahi creo todas las graficas tablas y demás que me apetezca????
+## TODO: MUEVO ESTO A UN ARCHIVO DE PANEL COMPONENTS / CHARTS / TABLES??????? y ahi creo todas las graficas tablas y demás que me apetezca????
 def get_risk_diversification_pie_chart(risk_criteria_name, weight_by_criteria_df, data_column, group_by_column):
     pie_chart_id = f"diversification_by_{risk_criteria_name}_pie_chart"
 
@@ -90,7 +91,22 @@ def get_risk_diversification_pie_chart(risk_criteria_name, weight_by_criteria_df
         template="vizro_dark"
         # template="plotly_dark"
     )
-    weight_by_criteria_pie_chart.update_layout(legend={'x': 1, 'y': 0.5})
+
+    pop_up_text_html = "<b>%{label} (%{percent})</b>  <br> " + data_column + ": %{value:,.2f}"
+
+    legend_format_dict = dict(
+        orientation="v",  # Set orientation to vertical ('v')
+        yanchor="top",    # Anchor the legend to the top
+        y=1,              # Position the legend at the top (y=1)
+        xanchor="left",   # Anchor the legend to the left
+        x=1.02,           # Position the legend slightly to the right of the chart (x=1.02)
+    )
+    pop_up_format_dict = dict(
+        font_size=22
+    )
+    weight_by_criteria_pie_chart.update_traces(hovertemplate=pop_up_text_html)
+    weight_by_criteria_pie_chart.update_layout(legend=legend_format_dict,
+                                               hoverlabel=pop_up_format_dict)
     weight_by_criteria_pie_chart_html_component = dcc.Graph(id=pie_chart_id,
                                                             figure=weight_by_criteria_pie_chart)
     return weight_by_criteria_pie_chart_html_component


### PR DESCRIPTION
[FIX] Now the legend of the pie charts does not overlap the pie chart and more items are shown in a legible way
[FIX] The Font Size of the Pop-Ups of the pie chart is bigger 
[FIX] The content of the Pop-Ups has been changed tor show the relevant information more clearly 
[FIX] The Numbers in the Pop-Ups of the pie chart have a . and , as separators ALWAYS